### PR TITLE
add prompt-cont-regexp for impala.

### DIFF
--- a/sql-impala.el
+++ b/sql-impala.el
@@ -69,6 +69,7 @@ The buffer with name BUFFER will be used or created."
 
 (sql-add-product 'impala "Cloudera Impala"
                  :prompt-regexp "^[^>]*> "
+                 :prompt-cont-regexp "^ *> "
                  :sqli-comint-func 'sql-comint-impala
                  :sqli-login sql-impala-login-params
                  :sqli-program 'sql-impala-program


### PR DESCRIPTION
It appears the definition of
`sql-interactive-remove-continuation-prompt` was updated in emacs
25(?) and `prompt-cont-regexp` now needs to be non-nil.

The symptom was the following error.
`error in process filter: sql-interactive-remove-continuation-prompt: Wrong type argument: stringp, nil`